### PR TITLE
feat: only verify storage root on `OutputV0AtBlock`

### DIFF
--- a/op-service/sources/l2_client.go
+++ b/op-service/sources/l2_client.go
@@ -182,14 +182,14 @@ func (s *L2Client) OutputV0AtBlock(ctx context.Context, blockHash common.Hash) (
 
 	proof, err := s.GetProof(ctx, predeploys.L2ToL1MessagePasserAddr, []common.Hash{}, blockHash.String())
 	if err != nil {
-		return nil, fmt.Errorf("failed to get contract proof at block %s: %w", blockHash, err)
+		return nil, fmt.Errorf("failed to get contract proof at address %s block %s: %w ", predeploys.L2ToL1MessagePasserAddr, blockHash, err)
 	}
 	if proof == nil {
 		return nil, fmt.Errorf("proof %w", ethereum.NotFound)
 	}
 	// make sure that the proof (including storage hash) that we retrieved is correct by verifying it against the state-root
-	if err := proof.Verify(head.Root()); err != nil {
-		return nil, fmt.Errorf("invalid withdrawal root hash, state root was %s: %w", head.Root(), err)
+	if err := proof.VerifyStorageRoot(); err != nil {
+		return nil, fmt.Errorf("invalid withdrawal storage proof, root was %s: %w", proof.StorageHash, err)
 	}
 	stateRoot := head.Root()
 	return &eth.OutputV0{


### PR DESCRIPTION
With https://github.com/ithacaxyz/odyssey/pull/97 or https://github.com/paradigmxyz/reth/pull/13009 we no longer return a valid account proof on `eth_getProof` for the withdrawal contract. Only a valid storage proof.

This endpoint `OutputV0AtBlock` is used by `op-proposer` to post the output roots to the L1, and so requires skipping the account proof check, only verifying the storage root.