### PR TITLE
Fix minor typos and clarify comments in dencun_fork_test.go & reorg_test.go

### DIFF
--- a/op-e2e/actions/derivation/reorg_test.go
+++ b/op-e2e/actions/derivation/reorg_test.go
@@ -275,7 +275,7 @@ func ReorgFlipFlop(gt *testing.T, deltaTimeOffset *hexutil.Uint64) {
 	miner.ActL1IncludeTx(sd.RollupCfg.Genesis.SystemConfig.BatcherAddr)(t)
 	miner.ActL1EndBlock(t)
 
-	// sync verifier to what ths sequencer submitted
+	// sync verifier to what this sequencer submitted
 	verifier.ActL1HeadSignal(t)
 	verifier.ActL2PipelineFull(t)
 	require.Equal(t, verifier.L2Safe(), sequencer.L2Unsafe(), "verifier syncs from sequencer")

--- a/op-e2e/actions/upgrades/dencun_fork_test.go
+++ b/op-e2e/actions/upgrades/dencun_fork_test.go
@@ -121,7 +121,7 @@ func TestDencunL2ForkAfterGenesis(gt *testing.T) {
 	t := helpers.NewDefaultTesting(gt)
 	dp := e2eutils.MakeDeployParams(t, helpers.DefaultRollupTestParams())
 	require.Zero(t, *dp.DeployConfig.L1CancunTimeOffset)
-	// This test wil fork on the second block
+	// This test will fork on the second block
 	offset := hexutil.Uint64(dp.DeployConfig.L2BlockTime * 2)
 	dp.DeployConfig.L2GenesisEcotoneTimeOffset = &offset
 	dp.DeployConfig.L2GenesisFjordTimeOffset = nil


### PR DESCRIPTION
This PR fixes typos and clarifies comments in the test files dencun_fork_test.go and reorg_test.go. 
No functional changes were introduced—only improvements to readability and clarity.
